### PR TITLE
Naming consistency; saving window config; lighter

### DIFF
--- a/interleave.el
+++ b/interleave.el
@@ -44,16 +44,27 @@
 
 (require 'org)
 
-(when (not (featurep 'pdf-view))
-  (require 'doc-view))
+(require 'doc-view)
+;; Redefining `doc-view-kill-proc-and-buffer' as `interleave--doc-view-kill-proc-and-buffer'
+;; because this function is obsolete in emacs 25.1 onwards.
+(defun interleave--doc-view-kill-proc-and-buffer ()
+  "Kill the current converter process and buffer."
+  (interactive)
+  (doc-view-kill-proc)
+  (when (eq major-mode 'doc-view-mode)
+    (kill-buffer (current-buffer))))
 
 (defvar *interleave--org-buf* nil "The Org Buffer")
 
+(defvar interleave--window-configuration nil
+  "Variable to store the window configuration before interleave mode was
+enabled.")
+
 (make-variable-buffer-local
- (defvar *interleave-page-marker* 0
+ (defvar *interleave--page-marker* 0
    "Caches the current page while scrolling"))
 
-(defun interleave-find-pdf-path (buffer)
+(defun interleave--find-pdf-path (buffer)
   "Searches for the 'interleave_pdf' property in BUFFER and extracts it when found"
   (with-current-buffer buffer
     (save-excursion
@@ -62,7 +73,7 @@
       (when (match-string 0)
         (match-string 1)))))
 
-(defun interleave-open-file (split-window)
+(defun interleave--open-file (split-window)
   "Opens the interleave pdf file in doc-view besides the notes buffer.
 
 SPLIT-WINDOW is a function that actually splits the window, so it must be either
@@ -70,13 +81,14 @@ SPLIT-WINDOW is a function that actually splits the window, so it must be either
   (let ((buf (current-buffer)))
     (condition-case nil
         (progn
+          (delete-other-windows)
           (funcall split-window)
-          (find-file (expand-file-name (interleave-find-pdf-path buf)))
-          (interleave-docview-mode 1))
+          (find-file (expand-file-name (interleave--find-pdf-path buf)))
+          (interleave-pdf-mode 1))
       ('error (message "Please specify PDF file with #+INTERLEAVE_PDF document property.")
-              (interleave-quit)))))
+              (interleave--quit)))))
 
-(defun interleave-go-to-page-note (page)
+(defun interleave--go-to-page-note (page)
   "Searches the notes buffer for an headline with the 'interleave_page_note' property set
 to PAGE. It narrows the subtree when found."
   (with-current-buffer *interleave--org-buf*
@@ -88,7 +100,15 @@ to PAGE. It narrows the subtree when found."
         (org-show-entry)
         t))))
 
-(defun interleave-create-new-note (page)
+(defun interleave--switch-to-other-window ()
+  (other-window 1)
+  (goto-char (point-max))
+  (redisplay)
+  ;; Insert a new line if not already on a new line
+  (when (not (looking-back "^ *"))
+    (org-return)))
+
+(defun interleave--create-new-note (page)
   "Creates a new headline for the page PAGE."
   (with-current-buffer *interleave--org-buf*
     (save-excursion
@@ -97,97 +117,92 @@ to PAGE. It narrows the subtree when found."
       (org-insert-heading-respect-content)
       (insert (format "Notes for page %d" page))
       (org-set-property "interleave_page_note" (number-to-string page))
-      (org-narrow-to-subtree)
-      (other-window 1))))
+      (org-narrow-to-subtree)))
+  (interleave--switch-to-other-window))
 
 (if (featurep 'pdf-view) ; if `pdf-tools' is installed
     (progn
-      (defun interleave-go-to-next-page ()
+      (defun interleave--go-to-next-page ()
         "Go to the next page in PDF. Look up for available notes."
         (interactive)
         (pdf-view-next-page-command 1)
-        (interleave-go-to-page-note (pdf-view-current-page)))
+        (interleave--go-to-page-note (pdf-view-current-page)))
 
-      (defun interleave-go-to-previous-page ()
+      (defun interleave--go-to-previous-page ()
         "Go to the previous page in PDF. Look up for available notes."
         (interactive)
         (pdf-view-previous-page-command 1)
-        (interleave-go-to-page-note (pdf-view-current-page)))
+        (interleave--go-to-page-note (pdf-view-current-page)))
 
-      (defun interleave-scroll-up ()
+      (defun interleave--scroll-up ()
         "Scroll up the PDF. Look up for available notes."
         (interactive)
-        (setq *interleave-page-marker* (pdf-view-current-page))
+        (setq *interleave--page-marker* (pdf-view-current-page))
         (pdf-view-scroll-up-or-next-page)
-        (unless (= *interleave-page-marker* (pdf-view-current-page))
-          (interleave-go-to-page-note (pdf-view-current-page))))
+        (unless (= *interleave--page-marker* (pdf-view-current-page))
+          (interleave--go-to-page-note (pdf-view-current-page))))
 
-      (defun interleave-scroll-down ()
+      (defun interleave--scroll-down ()
         "Scroll down the PDF. Look up for available notes."
         (interactive)
-        (setq *interleave-page-marker* (pdf-view-current-page))
+        (setq *interleave--page-marker* (pdf-view-current-page))
         (pdf-view-scroll-down-or-previous-page)
-        (unless (= *interleave-page-marker* (pdf-view-current-page))
-          (interleave-go-to-page-note (pdf-view-current-page))))
+        (unless (= *interleave--page-marker* (pdf-view-current-page))
+          (interleave--go-to-page-note (pdf-view-current-page))))
 
-      (defun interleave-add-note ()
+      (defun interleave--add-note ()
         "Add note for the current page. If there are already notes for this page,
 jump to the notes buffer."
         (interactive)
         (let ((page (pdf-view-current-page)))
-          (with-current-buffer *interleave--org-buf*
-            (save-excursion
-              (if (interleave-go-to-page-note page)
-                  (other-window 1)
-                (interleave-create-new-note page)))))))
+          (if (interleave--go-to-page-note page)
+              (interleave--switch-to-other-window)
+            (interleave--create-new-note page)))))
   (progn ; if `pdf-tools' is NOT installed
-    (defun interleave-go-to-next-page ()
+    (defun interleave--go-to-next-page ()
       "Go to the next page in PDF. Look up for available notes."
       (interactive)
       (doc-view-next-page)
-      (interleave-go-to-page-note (doc-view-current-page)))
+      (interleave--go-to-page-note (doc-view-current-page)))
 
-    (defun interleave-go-to-previous-page ()
+    (defun interleave--go-to-previous-page ()
       "Go to the previous page in PDF. Look up for available notes."
       (interactive)
       (doc-view-previous-page)
-      (interleave-go-to-page-note (doc-view-current-page)))
+      (interleave--go-to-page-note (doc-view-current-page)))
 
-    (defun interleave-scroll-up ()
+    (defun interleave--scroll-up ()
       "Scroll up the PDF. Look up for available notes."
       (interactive)
-      (setq *interleave-page-marker* (doc-view-current-page))
+      (setq *interleave--page-marker* (doc-view-current-page))
       (doc-view-scroll-up-or-next-page)
-      (unless (= *interleave-page-marker* (doc-view-current-page))
-        (interleave-go-to-page-note (doc-view-current-page))))
+      (unless (= *interleave--page-marker* (doc-view-current-page))
+        (interleave--go-to-page-note (doc-view-current-page))))
 
-    (defun interleave-scroll-down ()
+    (defun interleave--scroll-down ()
       "Scroll down the PDF. Look up for available notes."
       (interactive)
-      (setq *interleave-page-marker* (doc-view-current-page))
+      (setq *interleave--page-marker* (doc-view-current-page))
       (doc-view-scroll-down-or-previous-page)
-      (unless (= *interleave-page-marker* (doc-view-current-page))
-        (interleave-go-to-page-note (doc-view-current-page))))
+      (unless (= *interleave--page-marker* (doc-view-current-page))
+        (interleave--go-to-page-note (doc-view-current-page))))
 
-    (defun interleave-add-note ()
+    (defun interleave--add-note ()
       "Add note for the current page. If there are already notes for this page,
 jump to the notes buffer."
       (interactive)
       (let ((page (doc-view-current-page)))
-        (with-current-buffer *interleave--org-buf*
-          (save-excursion
-            (if (interleave-go-to-page-note page)
-                (other-window 1)
-              (interleave-create-new-note page))))))))
+        (if (interleave--go-to-page-note page)
+            (interleave--switch-to-other-window)
+          (interleave--create-new-note page))))))
 
-(defun interleave-quit ()
+(defun interleave--quit ()
   "Quit interleave mode."
   (interactive)
   (with-current-buffer *interleave--org-buf*
     (widen)
     (interleave 0))
-  (doc-view-kill-proc-and-buffer)
-  (delete-window))
+  (interleave--doc-view-kill-proc-and-buffer))
 
 ;;;###autoload
 (define-minor-mode interleave
@@ -212,23 +227,29 @@ M-x interleave
 To insert a note for a page, type 'i'.
 Navigation is the same as in `doc-view-mode'."
   :lighter " Interleave"
-  (when interleave
-    (setq *interleave--org-buf* (current-buffer))
-    (interleave-open-file (or (and current-prefix-arg 'split-window-below)
-                              'split-window-right))))
+  (if interleave
+      ;; Stuff to do when enabling `interleave'
+      (progn
+        (setq interleave--window-configuration (current-window-configuration))
+        (setq *interleave--org-buf* (current-buffer))
+        (interleave--open-file (or (and current-prefix-arg 'split-window-below)
+                                   'split-window-right)))
+    ;; Stuff to do when disabling `interleave'
+    (progn
+      (set-window-configuration interleave--window-configuration))))
 
 ;;;###autoload
-(define-minor-mode interleave-docview-mode
-  "Interleave view for doc-view"
-  :lighter " Interleave-DocView"
+(define-minor-mode interleave-pdf-mode
+  "Interleave view for the pdf."
+  :lighter " ≡"
   :keymap (let ((map (make-sparse-keymap)))
-            (define-key map (kbd "n")     #'interleave-go-to-next-page)
-            (define-key map (kbd "p")     #'interleave-go-to-previous-page)
-            (define-key map (kbd "SPC")   #'interleave-scroll-up)
-            (define-key map (kbd "S-SPC") #'interleave-scroll-down)
-            (define-key map (kbd "DEL")   #'interleave-scroll-down)
-            (define-key map (kbd "i")     #'interleave-add-note)
-            (define-key map (kbd "q")     #'interleave-quit)
+            (define-key map (kbd "n")     #'interleave--go-to-next-page)
+            (define-key map (kbd "p")     #'interleave--go-to-previous-page)
+            (define-key map (kbd "SPC")   #'interleave--scroll-up)
+            (define-key map (kbd "S-SPC") #'interleave--scroll-down)
+            (define-key map (kbd "DEL")   #'interleave--scroll-down)
+            (define-key map (kbd "i")     #'interleave--add-note)
+            (define-key map (kbd "q")     #'interleave--quit)
             map))
 
 

--- a/interleave.el
+++ b/interleave.el
@@ -43,7 +43,9 @@
 ;;; Code:
 
 (require 'org)
-(require 'doc-view)
+
+(when (not (featurep 'pdf-view))
+  (require 'doc-view))
 
 (defvar *interleave--org-buf* nil "The Org Buffer")
 
@@ -78,13 +80,13 @@ SPLIT-WINDOW is a function that actually splits the window, so it must be either
   "Searches the notes buffer for an headline with the 'interleave_page_note' property set
 to PAGE. It narrows the subtree when found."
   (with-current-buffer *interleave--org-buf*
-      (save-excursion
-        (widen)
-        (goto-char (point-min))
-        (when (re-search-forward (format "^\[ \t\r\]*\:interleave_page_note\: %s$" page) nil t)
-          (org-narrow-to-subtree)
-          (org-show-entry)
-          t))))
+    (save-excursion
+      (widen)
+      (goto-char (point-min))
+      (when (re-search-forward (format "^\[ \t\r\]*\:interleave_page_note\: %s$" page) nil t)
+        (org-narrow-to-subtree)
+        (org-show-entry)
+        t))))
 
 (defun interleave-create-new-note (page)
   "Creates a new headline for the page PAGE."
@@ -98,63 +100,85 @@ to PAGE. It narrows the subtree when found."
       (org-narrow-to-subtree)
       (other-window 1))))
 
-(defun interleave-go-to-next-page ()
-  "Go to the next page in PDF. Look up for available notes."
-  (interactive)
-  (doc-view-next-page)
-  (interleave-go-to-page-note (doc-view-current-page)))
+(if (featurep 'pdf-view) ; if `pdf-tools' is installed
+    (progn
+      (defun interleave-go-to-next-page ()
+        "Go to the next page in PDF. Look up for available notes."
+        (interactive)
+        (pdf-view-next-page-command 1)
+        (interleave-go-to-page-note (pdf-view-current-page)))
 
-(defun interleave-go-to-previous-page ()
-  "Go to the previous page in PDF. Look up for available notes."
-  (interactive)
-  (doc-view-previous-page)
-  (interleave-go-to-page-note (doc-view-current-page)))
+      (defun interleave-go-to-previous-page ()
+        "Go to the previous page in PDF. Look up for available notes."
+        (interactive)
+        (pdf-view-previous-page-command 1)
+        (interleave-go-to-page-note (pdf-view-current-page)))
 
-(defun interleave-scroll-up ()
-  "Scroll up the PDF. Look up for available notes."
-  (interactive)
-  (setq *interleave-page-marker* (doc-view-current-page))
-  (doc-view-scroll-up-or-next-page)
-  (unless (= *interleave-page-marker* (doc-view-current-page))
-    (interleave-go-to-page-note (doc-view-current-page))))
+      (defun interleave-scroll-up ()
+        "Scroll up the PDF. Look up for available notes."
+        (interactive)
+        (setq *interleave-page-marker* (pdf-view-current-page))
+        (pdf-view-scroll-up-or-next-page)
+        (unless (= *interleave-page-marker* (pdf-view-current-page))
+          (interleave-go-to-page-note (pdf-view-current-page))))
 
-(defun interleave-scroll-down ()
-  "Scroll down the PDF. Look up for available notes."
-  (interactive)
-  (setq *interleave-page-marker* (doc-view-current-page))
-  (doc-view-scroll-down-or-previous-page)
-  (unless (= *interleave-page-marker* (doc-view-current-page))
-    (interleave-go-to-page-note (doc-view-current-page))))
+      (defun interleave-scroll-down ()
+        "Scroll down the PDF. Look up for available notes."
+        (interactive)
+        (setq *interleave-page-marker* (pdf-view-current-page))
+        (pdf-view-scroll-down-or-previous-page)
+        (unless (= *interleave-page-marker* (pdf-view-current-page))
+          (interleave-go-to-page-note (pdf-view-current-page))))
 
-(defun interleave-add-note ()
-  "Add note for the current page. If there are already notes for this page,
+      (defun interleave-add-note ()
+        "Add note for the current page. If there are already notes for this page,
 jump to the notes buffer."
-  (interactive)
-  (let ((page (doc-view-current-page)))
-    (with-current-buffer *interleave--org-buf*
-      (save-excursion
-        (if (interleave-go-to-page-note page)
-            (other-window 1)
-          (interleave-create-new-note page))))))
+        (interactive)
+        (let ((page (pdf-view-current-page)))
+          (with-current-buffer *interleave--org-buf*
+            (save-excursion
+              (if (interleave-go-to-page-note page)
+                  (other-window 1)
+                (interleave-create-new-note page)))))))
+  (progn ; if `pdf-tools' is NOT installed
+    (defun interleave-go-to-next-page ()
+      "Go to the next page in PDF. Look up for available notes."
+      (interactive)
+      (doc-view-next-page)
+      (interleave-go-to-page-note (doc-view-current-page)))
 
-(when (featurep 'pdf-view) ; if `pdf-tools' is installed
+    (defun interleave-go-to-previous-page ()
+      "Go to the previous page in PDF. Look up for available notes."
+      (interactive)
+      (doc-view-previous-page)
+      (interleave-go-to-page-note (doc-view-current-page)))
 
-  (defun interleave-pdf-view-after-page ()
-    "Go to the page's notes after the page has been changend with `pdf-tools'."
-    (interleave-go-to-page-note (pdf-view-current-page)))
+    (defun interleave-scroll-up ()
+      "Scroll up the PDF. Look up for available notes."
+      (interactive)
+      (setq *interleave-page-marker* (doc-view-current-page))
+      (doc-view-scroll-up-or-next-page)
+      (unless (= *interleave-page-marker* (doc-view-current-page))
+        (interleave-go-to-page-note (doc-view-current-page))))
 
-  (add-hook 'pdf-view-change-page-hook 'interleave-pdf-view-after-page)
+    (defun interleave-scroll-down ()
+      "Scroll down the PDF. Look up for available notes."
+      (interactive)
+      (setq *interleave-page-marker* (doc-view-current-page))
+      (doc-view-scroll-down-or-previous-page)
+      (unless (= *interleave-page-marker* (doc-view-current-page))
+        (interleave-go-to-page-note (doc-view-current-page))))
 
-  (defun interleave-add-note-pdf-view ()
-    "Add note for the current page. If there are already notes for this page,
-jump to the notes buffer. Applies if `pdf-tools' are installed."
-    (interactive)
-    (let ((page (pdf-view-current-page)))
-      (with-current-buffer *interleave--org-buf*
-        (save-excursion
-          (if (interleave-go-to-page-note page)
-              (other-window 1)
-            (interleave-create-new-note page)))))))
+    (defun interleave-add-note ()
+      "Add note for the current page. If there are already notes for this page,
+jump to the notes buffer."
+      (interactive)
+      (let ((page (doc-view-current-page)))
+        (with-current-buffer *interleave--org-buf*
+          (save-excursion
+            (if (interleave-go-to-page-note page)
+                (other-window 1)
+              (interleave-create-new-note page))))))))
 
 (defun interleave-quit ()
   "Quit interleave mode."
@@ -192,22 +216,19 @@ Navigation is the same as in `doc-view-mode'."
     (setq *interleave--org-buf* (current-buffer))
     (interleave-open-file (or (and current-prefix-arg 'split-window-below)
                               'split-window-right))))
+
 ;;;###autoload
 (define-minor-mode interleave-docview-mode
   "Interleave view for doc-view"
   :lighter " Interleave-DocView"
   :keymap (let ((map (make-sparse-keymap)))
-            (define-key map (kbd "q") 'interleave-quit)
-            (if (featurep 'pdf-view)
-                (progn
-                  (define-key map (kbd "i") 'interleave-add-note-pdf-view))
-              (progn
-                  (define-key map (kbd "n") 'interleave-go-to-next-page)
-                  (define-key map (kbd "p") 'interleave-go-to-previous-page)
-                  (define-key map (kbd "SPC") 'interleave-scroll-up)
-                  (define-key map (kbd "S-SPC") 'interleave-scroll-down)
-                  (define-key map (kbd "DEL") 'interleave-scroll-down)
-                  (define-key map (kbd "i") 'interleave-add-note)))
+            (define-key map (kbd "n")     #'interleave-go-to-next-page)
+            (define-key map (kbd "p")     #'interleave-go-to-previous-page)
+            (define-key map (kbd "SPC")   #'interleave-scroll-up)
+            (define-key map (kbd "S-SPC") #'interleave-scroll-down)
+            (define-key map (kbd "DEL")   #'interleave-scroll-down)
+            (define-key map (kbd "i")     #'interleave-add-note)
+            (define-key map (kbd "q")     #'interleave-quit)
             map))
 
 


### PR DESCRIPTION
Hi,

The following implementation to make the interleave mode work with pdf files viewed using `pdf-view` did not work for me; it started throwing error backtraces.

``` el
(defun interleave-pdf-view-after-page ()
    "Go to the page's notes after the page has been changend with `pdf-tools'."
    (interleave-go-to-page-note (pdf-view-current-page)))

  (add-hook 'pdf-view-change-page-hook 'interleave-pdf-view-after-page)
```

So I went ahead and reverted my fork to the earlier implementation of simply redefining the `interleave--` functions if `pdf-view` is used.

In addition, I made few house-keeping and minor feature-addition changes:
- All the package variable and function names now begin with
  `interleave--`
- Added explicit definition of the `doc-view-kill-proc-and-buffer`
  function (from emacs 24.4 source) in the package itself as that
  function's behavior changes to a mere current buffer kill in emacs
  25.1 onwards.
- The window configurations are saved and restored when entering and
  exiting the `interleave` mode.
- `interleave-create-new-note` function is modified to enter a new line
  if the point is not already on a new line.
- `interleave--create-new-note` and `interleave--add-note` functions are
  modified to use the new `interleave--switch-to-other-window` function.
- `interleave-docview-mode` is renamed to a more generic name
  `interleave-pdf-mode` because the pdf file could be viewed in
  `doc-view-mode`, `pdf-view-mode` (pdf-tools) and any other mode too?
- `interleave` mode lighter changed to  `≡` for its succinctness 
