### PR TITLE
Enable opening org note files directly from pdf

### DIFF
--- a/interleave.el
+++ b/interleave.el
@@ -289,10 +289,6 @@ of .pdf)."
                                 ;; listed as the first element in
                                 ;; `interleave--org-notes-dir-list'
                                 (setq org-file-create-dir dir))
-                              (message "cnt %0d dir %0s dirc %0s"
-                                       cnt
-                                       dir
-                                       org-file-create-dir)
                               (setq cnt (1+ cnt))
                               (setq try-org-file-name (locate-file
                                                        org-file-name-sans-directory


### PR DESCRIPTION
- When in a pdf buffer, if interleave is not yet enabled, hitting `i`
  will open its corresponding notes org file.
- The notes file is searched in the order the directory names are listed
  in the `interleave--org-notes-dir-list` custom variable. The first
  successfully matched org file is opened. If a directory name is ".",
  the search will also happen in the same directory as the pdf file.
- If the notes file is not found in any of the directories in the list,
  it is created in the FIRST directory from the list.
- The default value of this list is: '("~/org/interleave_notes" "."). So
  by default, if for a pdf file "/path/to/filexyz.pdf" its notes file
  does not exist, then its notes org file will be created as
  "~/org/interleave_notes/filexyz.org".
