### PR TITLE
Change all command names to be public functions

### DIFF
--- a/interleave.el
+++ b/interleave.el
@@ -155,19 +155,19 @@ property set to PAGE. It narrows the subtree when found."
         (org-show-entry)
         t))))
 
-(defun interleave--go-to-next-page ()
+(defun interleave-go-to-next-page ()
   "Go to the next page in PDF. Look up for available notes."
   (interactive)
   (funcall interleave--pdf-next-page-fn)
   (interleave--go-to-page-note (funcall interleave--pdf-current-page-fn)))
 
-(defun interleave--go-to-previous-page ()
+(defun interleave-go-to-previous-page ()
   "Go to the previous page in PDF. Look up for available notes."
   (interactive)
   (funcall interleave--pdf-previous-page-fn)
   (interleave--go-to-page-note (funcall interleave--pdf-current-page-fn)))
 
-(defun interleave--scroll-up ()
+(defun interleave-scroll-up ()
   "Scroll up the PDF. Look up for available notes."
   (interactive)
   (setq *interleave--page-marker* (funcall interleave--pdf-current-page-fn))
@@ -175,7 +175,7 @@ property set to PAGE. It narrows the subtree when found."
   (unless (= *interleave--page-marker* (funcall interleave--pdf-current-page-fn))
     (interleave--go-to-page-note (funcall interleave--pdf-current-page-fn))))
 
-(defun interleave--scroll-down ()
+(defun interleave-scroll-down ()
   "Scroll down the PDF. Look up for available notes."
   (interactive)
   (setq *interleave--page-marker* (funcall interleave--pdf-current-page-fn))
@@ -212,7 +212,7 @@ property set to PAGE. It narrows the subtree when found."
       (org-narrow-to-subtree)))
   (interleave--switch-to-org-buffer t))
 
-(defun interleave--add-note ()
+(defun interleave-add-note ()
   "Add note for the current page. If there are already notes for this page,
 jump to the notes buffer."
   (interactive)
@@ -439,12 +439,12 @@ Keybindings (org-mode buffer):
 (define-key interleave-map (kbd "M-p") #'interleave--sync-pdf-page-previous)
 (define-key interleave-map (kbd "M-n") #'interleave--sync-pdf-page-next)
 
-(define-key interleave-pdf-mode-map (kbd "n")     #'interleave--go-to-next-page)
-(define-key interleave-pdf-mode-map (kbd "p")     #'interleave--go-to-previous-page)
-(define-key interleave-pdf-mode-map (kbd "SPC")   #'interleave--scroll-up)
-(define-key interleave-pdf-mode-map (kbd "S-SPC") #'interleave--scroll-down)
-(define-key interleave-pdf-mode-map (kbd "DEL")   #'interleave--scroll-down)
-(define-key interleave-pdf-mode-map (kbd "i")     #'interleave--add-note)
+(define-key interleave-pdf-mode-map (kbd "n")     #'interleave-go-to-next-page)
+(define-key interleave-pdf-mode-map (kbd "p")     #'interleave-go-to-previous-page)
+(define-key interleave-pdf-mode-map (kbd "SPC")   #'interleave-scroll-up)
+(define-key interleave-pdf-mode-map (kbd "S-SPC") #'interleave-scroll-down)
+(define-key interleave-pdf-mode-map (kbd "DEL")   #'interleave-scroll-down)
+(define-key interleave-pdf-mode-map (kbd "i")     #'interleave-add-note)
 (define-key interleave-pdf-mode-map (kbd "q")     #'interleave--quit)
 (define-key interleave-pdf-mode-map (kbd "M-.")   #'interleave--sync-pdf-page-current)
 (define-key interleave-pdf-mode-map (kbd "M-p")   #'interleave--sync-pdf-page-previous)

--- a/interleave.el
+++ b/interleave.el
@@ -59,7 +59,7 @@
             (derived-mode-p 'pdf-view-mode))
     (kill-buffer (current-buffer))))
 
-(defcustom interleave--org-notes-dir-list '("~/org/interleave_notes"
+(defcustom interleave-org-notes-dir-list '("~/org/interleave_notes"
                                             ".")
   "List of directories to look into when opening interleave notes org from a
 pdf file. The notes file is assumed to have the exact same base name as the pdf
@@ -292,7 +292,7 @@ of .pdf)."
            (cnt 0)
            try-org-file-name
            (org-file-name (catch 'break
-                            (dolist (dir interleave--org-notes-dir-list)
+                            (dolist (dir interleave-org-notes-dir-list)
                               ;; If dir is "." or begins with "./", replace
                               ;; the "." or "./" with the pdf dir name
                               (setq dir (replace-regexp-in-string
@@ -303,7 +303,7 @@ of .pdf)."
                                 ;; In the event the org file is needed to be
                                 ;; created, it will be created in the directory
                                 ;; listed as the first element in
-                                ;; `interleave--org-notes-dir-list'
+                                ;; `interleave-org-notes-dir-list'
                                 (setq org-file-create-dir dir))
                               (setq cnt (1+ cnt))
                               (setq try-org-file-name (locate-file
@@ -314,7 +314,7 @@ of .pdf)."
                                 (throw 'break try-org-file-name))))))
       ;; Create the notes org file if it does not exist
       (when (null org-file-name)
-        (setq org-file-name (if (null interleave--org-notes-dir-list)
+        (setq org-file-name (if (null interleave-org-notes-dir-list)
                                 (read-file-name "Path: " "~/")
                               (progn
                                 (when (null (file-exists-p org-file-create-dir))
@@ -334,7 +334,7 @@ of .pdf)."
     (widen)
     (goto-char (point-min))
     (when (interleave--headlines-available-p)
-      (interleave--sort-notes interleave--sort-order)
+      (interleave--sort-notes interleave-sort-order)
       (org-overview))
     (interleave 0))
   (interleave--pdf-kill-proc-and-buffer))
@@ -343,7 +343,7 @@ of .pdf)."
   (save-excursion
     (re-search-forward "^\* .*" nil t)))
 
-(defcustom interleave--sort-order 'asc
+(defcustom interleave-sort-order 'asc
   "Specifiy the notes' sort order in the notes buffer.
 
 The possible values are 'asc for ascending and 'desc for descending."


### PR DESCRIPTION
This PR changes all command and custom variable names that were private (using double dash in the name) to be public.
