### PR TITLE
Make interleave--find-pdf-path work in narrow buf

### DIFF
--- a/interleave.el
+++ b/interleave.el
@@ -118,11 +118,12 @@ the pdf directory name. e.g. \".\" is interpreted as \"/pdf/file/dir/\",
 (defun interleave--find-pdf-path (buffer)
   "Searches for the `interleave_pdf' property in BUFFER and extracts it when found."
   (with-current-buffer buffer
-    (save-excursion
-      (goto-char (point-min))
-      (re-search-forward "^#\\+interleave_pdf: \\(.*\\)")
-      (when (match-string 0)
-        (match-string 1)))))
+    (save-restriction
+      (widen)
+      (save-excursion
+        (goto-char (point-min))
+        (when (re-search-forward "^#\\+interleave_pdf: \\(.*\\)" nil :noerror)
+          (match-string 1))))))
 
 (defun interleave--headline-pdf-path (buffer)
   (with-current-buffer buffer


### PR DESCRIPTION
Earlier, if you were in an interleave created .org file in a state narrowed to some heading, and if you did `M-x interleave`, it would not work even if you had the `#+interleave_pdf:` header at the very top.

The fix is to temporarily `widen` the buffer (in `save-restriction`).
