### PR TITLE
Support Emacs 24 with `interleave-disable-narrowing' enabled

### DIFF
--- a/interleave.el
+++ b/interleave.el
@@ -680,7 +680,7 @@ Keybindings (org-mode buffer):
                 (interleave--goto-search-position)
                 (if interleave-multi-pdf-notes-file
                     (org-show-subtree) 
-                  (outline-show-all))
+                  (show-all))
                 (org-cycle-hide-drawers 'all)))
             (interleave--go-to-page-note 1)
             (message "Interleave enabled"))


### PR DESCRIPTION
outline-show-all is introduced in outline.el in Emacs 25. Replace it
with `show-all' which exists in Emacs 24 and is aliased to
outline-show-all in Emacs 25.

A similar thing was done in spacemacs: https://github.com/syl20bnr/spacemacs/pull/6527.