### PR TITLE
Check insert-relative-name option when the file is first created

### DIFF
--- a/interleave.el
+++ b/interleave.el
@@ -567,6 +567,8 @@ of .pdf)."
                                   (make-directory org-file-create-dir))
                                 (expand-file-name org-file-name-sans-directory
                                                   org-file-create-dir))))
+        (when interleave-insert-relative-name
+          (setq pdf-file-name (file-relative-name pdf-file-name)))
         (with-temp-file org-file-name
           (insert "#+INTERLEAVE_PDF: " pdf-file-name)))
       ;; Open the notes org file and enable `interleave-mode'


### PR DESCRIPTION
Normally, interleave--open-file function checks this customization but when opened using a keyboard shortcut, file is first created in interleave-open-notes-file-for-pdf which ignores this option